### PR TITLE
Add bedrock identifier support, for newer packs that do not use custo…

### DIFF
--- a/src/main/resources/Extension/Mappings/example.yml
+++ b/src/main/resources/Extension/Mappings/example.yml
@@ -4,6 +4,8 @@ mappings:
     type: "minecraft:iron_sword"
     # Custom model data, -1 represent ignore custom model data
     model-data: -1
+    # Identifier from Geyser Mappings file. This will override model-data search. Set to none to disable.
+    identifier: none
     # options
     displayentityoptions:
       # The y-offset of display entity


### PR DESCRIPTION
…m-model-data.

Logic flow:
check item identifier, and check for config string "identifier", if none existent or set to "none" then skip and use regular model-data logic.