### PR TITLE
fix: hide unmapped vanilla item-displays leaking

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "me.geyserextensionists"
-version = "1.0.9"
+version = "1.0.10"
 
 repositories {
     mavenCentral()

--- a/src/main/java/me/geyserextensionists/geyserdisplayentity/entity/ItemDisplayEntity.java
+++ b/src/main/java/me/geyserextensionists/geyserdisplayentity/entity/ItemDisplayEntity.java
@@ -1,6 +1,7 @@
 package me.geyserextensionists.geyserdisplayentity.entity;
 
 import me.geyserextensionists.geyserdisplayentity.GeyserDisplayEntity;
+import me.geyserextensionists.geyserdisplayentity.managers.ConfigManager;
 import me.geyserextensionists.geyserdisplayentity.type.DisplayType;
 import me.geyserextensionists.geyserdisplayentity.util.DeltaUtils;
 import me.geyserextensionists.geyserdisplayentity.util.FileConfiguration;
@@ -111,13 +112,21 @@ public class ItemDisplayEntity extends SlotDisplayEntity {
         String javaID = session.getItemMappings().getMapping(stack).getJavaItem().javaIdentifier();
         boolean wasHiddenByType = needHide;
 
-        // Keep hide-types behavior for vanilla items, but allow custom translated items
-        // (e.g. custom model data on minecraft:bone) to remain visible unless explicitly forced.
-        FileConfiguration rootConfig = GeyserDisplayEntity.getExtension().getConfigManager().getConfig();
-        boolean hiddenByType = rootConfig.getStringList("hide-types").contains(javaID);
-        boolean forceHiddenCustomType = rootConfig.getStringList("hide-custom-types").contains(javaID);
+        ConfigManager cfg = GeyserDisplayEntity.getExtension().getConfigManager();
+        boolean hiddenByType = cfg.getHideTypes().contains(javaID);
+        boolean forceHiddenCustomType = cfg.getHideCustomTypes().contains(javaID);
+        boolean unmappedVanilla = cfg.isHideUnmappedVanilla() && !custom && !mappingApplied;
 
-        if ((hiddenByType && !custom) || forceHiddenCustomType) {
+        boolean hidden = (hiddenByType && !custom) || forceHiddenCustomType || unmappedVanilla;
+
+        if (cfg.isLogDisplays()) {
+            GeyserDisplayEntity.getExtension().logger().info("ItemDisplay java=" + javaID
+                    + " bedrock=" + item.getDefinition().getIdentifier()
+                    + " custom=" + custom + " mapped=" + mappingApplied
+                    + " -> " + (hidden ? "HIDDEN" : "SHOWN"));
+        }
+
+        if (hidden) {
             setInvisible(true);
             needHide = true;
             this.dirtyMetadata.put(EntityDataTypes.SCALE, 0f);

--- a/src/main/java/me/geyserextensionists/geyserdisplayentity/managers/ConfigManager.java
+++ b/src/main/java/me/geyserextensionists/geyserdisplayentity/managers/ConfigManager.java
@@ -14,6 +14,11 @@ public class ConfigManager {
 
     private LinkedHashMap<String, FileConfiguration> configMappingsCache;
 
+    private Set<String> hideTypes = Set.of();
+    private Set<String> hideCustomTypes = Set.of();
+    private boolean hideUnmappedVanilla = true;
+    private boolean logDisplays = false;
+
     public ConfigManager() {
         load();
     }
@@ -21,6 +26,14 @@ public class ConfigManager {
     public void load() {
         this.config = new FileConfiguration("config.yml");
         this.lang = new FileConfiguration("Lang/messages.yml");
+
+        this.hideTypes = new HashSet<>(config.getStringList("hide-types"));
+        this.hideCustomTypes = config.contains("hide-custom-types")
+                ? new HashSet<>(config.getStringList("hide-custom-types"))
+                : this.hideTypes;
+        this.hideUnmappedVanilla = !config.contains("hide-unmapped-vanilla-displays")
+                || config.getBoolean("hide-unmapped-vanilla-displays");
+        this.logDisplays = config.getBoolean("settings.debug.log-displays");
 
         if (!Files.exists(GeyserDisplayEntity.getExtension().dataFolder().resolve("Mappings"))) FileUtils.createFiles(GeyserDisplayEntity.getExtension(), "Mappings/example.yml");
 
@@ -53,5 +66,21 @@ public class ConfigManager {
 
     public LinkedHashMap<String, FileConfiguration> getConfigMappingsCache() {
         return configMappingsCache;
+    }
+
+    public Set<String> getHideTypes() {
+        return hideTypes;
+    }
+
+    public Set<String> getHideCustomTypes() {
+        return hideCustomTypes;
+    }
+
+    public boolean isHideUnmappedVanilla() {
+        return hideUnmappedVanilla;
+    }
+
+    public boolean isLogDisplays() {
+        return logDisplays;
     }
 }

--- a/src/main/resources/Extension/config.yml
+++ b/src/main/resources/Extension/config.yml
@@ -19,6 +19,9 @@ hide-types:
 hide-custom-types:
   - "minecraft:leather_horse_armor"
 
+hide-unmapped-vanilla-displays: true
+
 settings:
   debug:
     per-player-load-mappings: false
+    log-displays: false


### PR DESCRIPTION
Item-displays show on Bedrock unless their item is in `hide-types`. That also catches server-side decorations (crate highlights, region markers), which then render as stray blocks around models.

We already compute `mappingApplied` but never use it, so this hooks into it: if a display matches no mapping and uses a vanilla item, hide it (`hide-unmapped-vanilla-displays`, on by default). Mapped displays and custom furniture are untouched.

Also fixed while in here:
- fall back to `hide-types` when `hide-custom-types` is missing (older configs keep hiding bones)
- added `settings.debug.log-displays` to log what each display resolves to
- cache the hide lists in `ConfigManager` instead of re-reading them on every display update

Tested on a live ModelEngine + crates setup. Stray block gone, boards and furniture still render. Can flip the default to opt-in if you prefer.