### PR TITLE
Render display-entity items as flat items

### DIFF
--- a/src/main/java/me/geyserextensionists/geyserdisplayentity/entity/ItemDisplayEntity.java
+++ b/src/main/java/me/geyserextensionists/geyserdisplayentity/entity/ItemDisplayEntity.java
@@ -56,7 +56,9 @@ public class ItemDisplayEntity extends SlotDisplayEntity {
 
         config = GeyserDisplayEntity.getExtension().getConfigManager().getConfig().getConfigurationSection("general");
 
-        ItemData item = ItemTranslator.translateToBedrock(session, stack);
+        // Render display-entity items as flat items so custom-block items keep their custom item
+        // definition (Geyser skips it for custom-block items unless this flag is set).
+        ItemData item = ItemTranslator.translateToBedrock(session, stack, true);
         this.item = item;
 
         if (item instanceof DyeableArmorItem) {


### PR DESCRIPTION
Pass the new renderAsItem flag to ItemTranslator.translateToBedrock so custom-block items shown on display entities keep their custom item definition. Geyser now skips the custom item definition for custom-block items unless this flag is set, so display entities need to opt in.