### PR TITLE
Fix NPE when general config section is missing in SlotDisplayEntity

### DIFF
--- a/src/main/java/me/geyserextensionists/geyserdisplayentity/entity/ItemDisplayEntity.java
+++ b/src/main/java/me/geyserextensionists/geyserdisplayentity/entity/ItemDisplayEntity.java
@@ -219,7 +219,7 @@ public class ItemDisplayEntity extends SlotDisplayEntity {
         ItemData helmet = ItemData.AIR; // TODO
         ItemData chest = item;
 
-        if (custom && !config.getBoolean("hand")) {
+        if (custom && !(config != null && config.getBoolean("hand"))) {
             MobArmorEquipmentPacket armorEquipmentPacket = new MobArmorEquipmentPacket();
             armorEquipmentPacket.setRuntimeEntityId(geyserId);
             armorEquipmentPacket.setHelmet(helmet);
@@ -290,7 +290,7 @@ public class ItemDisplayEntity extends SlotDisplayEntity {
 
     @Override
     public void moveAbsoluteRaw(Vector3f position, float yaw, float pitch, float headYaw, boolean isOnGround, boolean teleported) {
-        double yOffset = config.getDouble("y-offset");
+        double yOffset = config != null ? config.getDouble("y-offset") : -0.5;
         setPosition(position);
         setYaw(yaw);
         setPitch(pitch);

--- a/src/main/java/me/geyserextensionists/geyserdisplayentity/entity/SlotDisplayEntity.java
+++ b/src/main/java/me/geyserextensionists/geyserdisplayentity/entity/SlotDisplayEntity.java
@@ -67,7 +67,7 @@ public class SlotDisplayEntity extends Entity {
         propertyManager.addProperty(new FloatProperty(Identifier.of("geyser:s_y"), MAX_VALUE, MIN_VALUE, 0F), scale.getY());
         propertyManager.addProperty(new FloatProperty(Identifier.of("geyser:s_z"), MAX_VALUE, MIN_VALUE, 0F), scale.getZ());
 
-        if (config.getBoolean("vanilla-scale")) applyScale();
+        if (config != null && config.getBoolean("vanilla-scale")) applyScale();
 
         displayRotation = Vector3f.from(0, 0, 0);
         displayTranslation = Vector3f.from(0, 0, 0);
@@ -127,7 +127,7 @@ public class SlotDisplayEntity extends Entity {
     public void setScale(EntityMetadata<Vector3f, ?> entityMetadata) {
         this.scale = entityMetadata.getValue();
 
-        if (config.getBoolean("vanilla-scale")) applyScale();
+        if (config != null && config.getBoolean("vanilla-scale")) applyScale();
 
         propertyManager.addProperty(new FloatProperty(Identifier.of("geyser:s_x"), MAX_VALUE, MIN_VALUE, 0F), scale.getX());
         propertyManager.addProperty(new FloatProperty(Identifier.of("geyser:s_y"), MAX_VALUE, MIN_VALUE, 0F), scale.getY());
@@ -137,7 +137,7 @@ public class SlotDisplayEntity extends Entity {
     protected void applyScale() {
         Vector3f vector3f = this.scale;
         float scale = (vector3f.getX() + vector3f.getY() + vector3f.getZ()) / 3;
-        if (config.getBoolean("vanilla-scale")) scale *= (float) config.getDouble("vanilla-scale-multiplier");
+        if (config != null && config.getBoolean("vanilla-scale")) scale *= (float) config.getDouble("vanilla-scale-multiplier");
         this.metadata.put(EntityDataTypes.SCALE, scale);
     }
 


### PR DESCRIPTION
## Summary
- Guard against `config` being `null` in `SlotDisplayEntity` / `ItemDisplayEntity` when `getConfigurationSection("general")` returns `null`, falling back to safe defaults instead of throwing.
- Fixes a `NullPointerException` in `SlotDisplayEntity.initializeMetadata()` that crashed `ClientboundAddEntityPacket` translation on every display-entity spawn.

## Root cause
`getConfigurationSection("general")` returns `null` when the `general` section is missing from `config.yml` (e.g. configs generated by an older plugin version — `FileUtils.createFiles` only creates the file if it doesn't exist yet, it never merges newly added keys into an existing config). `SlotDisplayEntity` then called `config.getBoolean(...)` unconditionally, causing an NPE on every entity spawn.

## Changes
- `SlotDisplayEntity.java`: null-guard the `vanilla-scale` / `vanilla-scale-multiplier` lookups in `initializeMetadata()`, `setScale()`, and `applyScale()`.
- `ItemDisplayEntity.java`: null-guard the `hand` lookup in `updateMainHand()` and the `y-offset` lookup in `moveAbsoluteRaw()`, matching the null-safe pattern already used elsewhere in the class.