### PR TITLE
Fix y-offset not applying and zero entity height on Geyser 2.11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "me.geyserextensionists"
-version = "1.0.10"
+version = "1.0.11"
 
 repositories {
     mavenCentral()

--- a/src/main/java/me/geyserextensionists/geyserdisplayentity/GeyserDisplayEntity.java
+++ b/src/main/java/me/geyserextensionists/geyserdisplayentity/GeyserDisplayEntity.java
@@ -89,14 +89,14 @@ public class GeyserDisplayEntity implements Extension {
 
             BLOCK_DISPLAY = VanillaEntityType.inherited(BlockDisplayEntity::new, slotDisplayBase)
                     .type(EntityType.BLOCK_DISPLAY)
-                    .height(configManager.getConfig().getInt("general.height")).width(0.001f)
+                    .height(configManager.getConfig().getFloat("general.height")).width(0.001f)
                     .bedrockDefinition(BLOCK_DISPLAY_BEDROCK)
                     .addTranslator(MetadataTypes.BLOCK_STATE, BlockDisplayEntity::setDisplayedBlockState)
                     .build();
 
             ITEM_DISPLAY = VanillaEntityType.inherited(ItemDisplayEntity::new, slotDisplayBase)
                     .type(EntityType.ITEM_DISPLAY)
-                    .height(configManager.getConfig().getInt("general.height")).width(0.001f)
+                    .height(configManager.getConfig().getFloat("general.height")).width(0.001f)
                     .bedrockDefinition(ITEM_DISPLAY_BEDROCK)
                     .addTranslator(MetadataTypes.ITEM_STACK, ItemDisplayEntity::setDisplayedItem)
                     .addTranslator(MetadataTypes.BYTE, ItemDisplayEntity::setDisplayType)

--- a/src/main/java/me/geyserextensionists/geyserdisplayentity/entity/ItemDisplayEntity.java
+++ b/src/main/java/me/geyserextensionists/geyserdisplayentity/entity/ItemDisplayEntity.java
@@ -46,6 +46,12 @@ public class ItemDisplayEntity extends SlotDisplayEntity {
         moveAbsoluteRaw(position, yaw, pitch, headYaw, onGround, true);
     }
 
+    @Override
+    public Vector3f bedrockPosition() {
+        if (config == null) return super.bedrockPosition();
+        return super.bedrockPosition().up((float) config.getDouble("y-offset"));
+    }
+
     public void setDisplayedItem(EntityMetadata<ItemStack, ?> entityMetadata) {
         ItemStack stack = entityMetadata.getValue();
         if (stack == null) {


### PR DESCRIPTION
y-offset was sent as a follow-up move right after the spawn packet, and the client drops it when it lands in the same batch, so any display that never moved again ignored the offset entirely at any value. general.height was read with getInt(), which Configurate returns 0 for on a value like 1.7, and Geyser 2.11 sends HEIGHT unconditionally where 2.9.5 only sent it on change, so displays partly in the ground rendered black. Both confirmed fixed in game.
