### PR TITLE
apply y-offset when the mapping arrives after spawn

### DIFF
--- a/src/main/java/me/geyserextensionists/geyserdisplayentity/entity/ItemDisplayEntity.java
+++ b/src/main/java/me/geyserextensionists/geyserdisplayentity/entity/ItemDisplayEntity.java
@@ -300,18 +300,15 @@ public class ItemDisplayEntity extends SlotDisplayEntity {
 
     @Override
     public void moveAbsoluteRaw(Vector3f position, float yaw, float pitch, float headYaw, boolean isOnGround, boolean teleported) {
-        double yOffset = config == null ? 0 : config.getDouble("y-offset");
         setPosition(position);
         setYaw(yaw);
         setPitch(pitch);
         setHeadYaw(headYaw);
         setOnGround(isOnGround);
-        position = position.clone().add(0, yOffset, 0);
-        setOnGround(isOnGround);
 
         MoveEntityAbsolutePacket moveEntityPacket = new MoveEntityAbsolutePacket();
         moveEntityPacket.setRuntimeEntityId(geyserId);
-        moveEntityPacket.setPosition(position);
+        moveEntityPacket.setPosition(bedrockPosition());
         moveEntityPacket.setRotation(bedrockRotation());
         moveEntityPacket.setOnGround(isOnGround);
         moveEntityPacket.setTeleported(teleported);

--- a/src/main/java/me/geyserextensionists/geyserdisplayentity/entity/ItemDisplayEntity.java
+++ b/src/main/java/me/geyserextensionists/geyserdisplayentity/entity/ItemDisplayEntity.java
@@ -190,6 +190,10 @@ public class ItemDisplayEntity extends SlotDisplayEntity {
 
         if (config.getBoolean("vanilla-scale")) applyScale();
         applyMappingDisplayTransform(config);
+
+        if (valid) {
+            moveAbsoluteRaw(position, yaw, pitch, headYaw, onGround, true);
+        }
         return true;
     }
 
@@ -296,7 +300,7 @@ public class ItemDisplayEntity extends SlotDisplayEntity {
 
     @Override
     public void moveAbsoluteRaw(Vector3f position, float yaw, float pitch, float headYaw, boolean isOnGround, boolean teleported) {
-        double yOffset = config.getDouble("y-offset");
+        double yOffset = config == null ? 0 : config.getDouble("y-offset");
         setPosition(position);
         setYaw(yaw);
         setPitch(pitch);


### PR DESCRIPTION
`config` is only assigned in `setDisplayedItem`, which usually runs after `spawnEntity()` has sent the AddEntity packet and its follow-up move. Both resolve the position while `config` is still null, so neither carries the mapping's `y-offset`, and a display that never moves again never gets corrected. This re-sends the position once the mapping has been applied.

`moveAbsoluteRaw` also rebuilt the packet position by hand as `position + y-offset`, which duplicates `bedrockPosition()` while dropping the entity-definition offset it applies. Sending `bedrockPosition()` instead matches Geyser's own `Entity#moveAbsoluteRaw`, keeps both offsets, and means the method no longer reads `config` at all, so the spawn-time call can't NPE on it.

Tested with packet-spawned item displays: `y-offset` had no effect at any value before, and applies correctly after.